### PR TITLE
Add 'patch' package to removal exception.

### DIFF
--- a/shell/arch/docker/cleanup.sh
+++ b/shell/arch/docker/cleanup.sh
@@ -4,7 +4,7 @@
 if pacman -Qg "base-devel" > /dev/null ; then
 
 	# remove base devel excluding useful core packages
-	pacman -Ru $(pacman -Qgq base-devel | grep -v awk | grep -v pacman | grep -v sed | grep -v grep | grep -v gzip | grep -v which) --noconfirm
+	pacman -Ru $(pacman -Qgq base-devel | grep -v awk | grep -v pacman | grep -v sed | grep -v grep | grep -v gzip | grep -v which | grep -v patch) --noconfirm
 
 fi
 


### PR DESCRIPTION
Allow the 'patch' command line tool to not be removed by the cleanup.sh script. This is a helpful tool and has a use for a future PR which allows for disabling the password prompt in the Deluge WebUI in the binhex/arch-delugevpn repository.